### PR TITLE
#153727984 Allow user to set timeouts and grace values for days exceeding 30

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "${workspaceFolder}/hc-venv/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "${workspaceFolder}/hc-venv/bin/python"
-}

--- a/hc/api/schemas.py
+++ b/hc/api/schemas.py
@@ -2,8 +2,8 @@ check = {
     "properties": {
         "name": {"type": "string"},
         "tags": {"type": "string"},
-        "timeout": {"type": "number", "minimum": 60, "maximum": 604800},
-        "grace": {"type": "number", "minimum": 60, "maximum": 604800},
+        "timeout": {"type": "number", "minimum": 60, "maximum": 7776000},
+        "grace": {"type": "number", "minimum": 60, "maximum": 7776000},
         "channels": {"type": "string"}
     }
 }

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -21,11 +21,11 @@ class TimeoutForm(forms.Form):
     """
     User can set desired timeout and grace values
     Minimun: 60 seconds (1 minute)
-    Maximum: 31536000 seconds (365 days)
+    Maximum: 7776000 seconds (90 days)
     """
 
-    timeout = forms.IntegerField(min_value=60, max_value=31536000)
-    grace = forms.IntegerField(min_value=60, max_value=31536000)
+    timeout = forms.IntegerField(min_value=60, max_value=7776000)
+    grace = forms.IntegerField(min_value=60, max_value=7776000)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -18,8 +18,14 @@ class NameTagsForm(forms.Form):
 
 
 class TimeoutForm(forms.Form):
-    timeout = forms.IntegerField(min_value=60, max_value=2592000)
-    grace = forms.IntegerField(min_value=60, max_value=2592000)
+    """
+    User can set desired timeout and grace values
+    Minimun: 60 seconds (1 minute)
+    Maximum: 31536000 seconds (365 days)
+    """
+
+    timeout = forms.IntegerField(min_value=60, max_value=31536000)
+    grace = forms.IntegerField(min_value=60, max_value=31536000)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/hc/front/templatetags/hc_extras.py
+++ b/hc/front/templatetags/hc_extras.py
@@ -13,6 +13,7 @@ MINUTE = Unit("minute", 60)
 HOUR = Unit("hour", MINUTE.nsecs * 60)
 DAY = Unit("day", HOUR.nsecs * 24)
 WEEK = Unit("week", DAY.nsecs * 7)
+MONTH = Unit("month", DAY.nsecs * 30)
 
 
 @register.filter
@@ -20,7 +21,7 @@ def hc_duration(td):
     remaining_seconds = int(td.total_seconds())
     result = []
 
-    for unit in (WEEK, DAY, HOUR, MINUTE):
+    for unit in (MONTH, WEEK, DAY, HOUR, MINUTE):
         if unit == WEEK and remaining_seconds % unit.nsecs != 0:
             # Say "8 days" instead of "1 week 1 day"
             continue

--- a/hc/front/tests/test_hc_extras.py
+++ b/hc/front/tests/test_hc_extras.py
@@ -14,8 +14,8 @@ class HcExtrasTestCase(TestCase):
             (86400, "1 day"),
             (604800, "1 week"),
             (2419200, "4 weeks"),
-            (2592000, "30 days"),
-            (3801600, "44 days")
+            (2592000, "1 month"),
+            (7776000, "3 months")
         ]
 
         for seconds, expected_result in samples:

--- a/hc/front/tests/test_update_timeout.py
+++ b/hc/front/tests/test_update_timeout.py
@@ -70,9 +70,9 @@ class UpdateTimeoutTestCase(BaseTestCase):
         assert check.timeout.total_seconds() == 3600
         assert check.grace.total_seconds() == 60
 
-    def test_longer_timeout_grace_periods(self):
+    def test_longer_timeouts_grace_periods(self):
         """
-        Test that user can be able to set timeout and grace periods of longer than 30 days
+        Test that user can be able to set timeouts and grace periods of longer than 30 days
         """
         url = "/checks/%s/timeout/" % self.check.code
         payload = {"timeout": 7776000, "grace": 7776000}

--- a/hc/front/tests/test_update_timeout.py
+++ b/hc/front/tests/test_update_timeout.py
@@ -57,3 +57,29 @@ class UpdateTimeoutTestCase(BaseTestCase):
         self.client.login(username="charlie@example.org", password="password")
         r = self.client.post(url, data=payload)
         assert r.status_code == 403
+
+    def test_it_works(self):
+        url = "/checks/%s/timeout/" % self.check.code
+        payload = {"timeout": 3600, "grace": 60}
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.post(url, data=payload)
+        self.assertRedirects(r, "/checks/")
+
+        check = Check.objects.get(code=self.check.code)
+        assert check.timeout.total_seconds() == 3600
+        assert check.grace.total_seconds() == 60
+
+    def test_longer_timeout_grace_periods(self):
+        """
+        Test that user can be able to set timeout and grace periods of longer than 30 days
+        """
+        url = "/checks/%s/timeout/" % self.check.code
+        payload = {"timeout": 7776000, "grace": 7776000}
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.post(url, data=payload)
+
+        check = Check.objects.get(code=self.check.code)
+        assert check.timeout.total_seconds() == 7776000
+        assert check.grace.total_seconds() == 7776000

--- a/hc/front/tests/test_update_timeout.py
+++ b/hc/front/tests/test_update_timeout.py
@@ -75,11 +75,11 @@ class UpdateTimeoutTestCase(BaseTestCase):
         Test that user can be able to set timeouts and grace periods of longer than 30 days
         """
         url = "/checks/%s/timeout/" % self.check.code
-        payload = {"timeout": 7776000, "grace": 7776000}
+        payload = {"timeout": 5184000, "grace": 5184000}
 
         self.client.login(username="alice@example.org", password="password")
         r = self.client.post(url, data=payload)
 
         check = Check.objects.get(code=self.check.code)
-        assert check.timeout.total_seconds() == 7776000
-        assert check.grace.total_seconds() == 7776000
+        assert check.timeout.total_seconds() == 5184000
+        assert check.grace.total_seconds() == 5184000

--- a/hc/front/tests/test_update_timeout.py
+++ b/hc/front/tests/test_update_timeout.py
@@ -58,18 +58,6 @@ class UpdateTimeoutTestCase(BaseTestCase):
         r = self.client.post(url, data=payload)
         assert r.status_code == 403
 
-    def test_it_works(self):
-        url = "/checks/%s/timeout/" % self.check.code
-        payload = {"timeout": 3600, "grace": 60}
-
-        self.client.login(username="alice@example.org", password="password")
-        r = self.client.post(url, data=payload)
-        self.assertRedirects(r, "/checks/")
-
-        check = Check.objects.get(code=self.check.code)
-        assert check.timeout.total_seconds() == 3600
-        assert check.grace.total_seconds() == 60
-
     def test_longer_timeouts_grace_periods(self):
         """
         Test that user can be able to set timeouts and grace periods of longer than 30 days

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -4,7 +4,8 @@ $(function () {
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
     var WEEK = {name: "week", nsecs: DAY.nsecs * 7};
-    var UNITS = [WEEK, DAY, HOUR, MINUTE];
+    var MONTH = {name: "month", nsecs: DAY.nsecs * 30};
+    var UNITS = [MONTH, WEEK, DAY, HOUR, MINUTE];
 
     var secsToText = function(total) {
         var remainingSeconds = Math.floor(total);
@@ -37,13 +38,14 @@ $(function () {
         range: {
             'min': [60, 60],
             '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            '50%': [86400, 86400],
+            '66%': [604800, 604800],
+            '83%': [2592000, 2592000],
+            'max': 7776000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 1800, 3600, 86400, 604800, 2592000, 7776000],
             density: 4,
             format: {
                 to: secsToText,
@@ -66,13 +68,14 @@ $(function () {
         range: {
             'min': [60, 60],
             '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            '50%': [86400, 86400],
+            '66%': [604800, 604800],
+            '83%': [2592000, 2592000],
+            'max': 7776000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 1800, 3600, 86400, 604800, 2592000, 7776000],
             density: 4,
             format: {
                 to: secsToText,


### PR DESCRIPTION
#### What does this PR do?
* Extends the timeout and grace values that a user can set up to a maximum of 90 days.
* Restructures monitoring intervals to minutes, hours, days, weeks and months.

#### Description of Task to be completed?
* Change front end and back end restrictions that prevent prevent users from having cron jobs with timeout and grace values longer than 30 days.
* Change UI to allow user set minute-wise, hourly, daily, weekly and monthly monitoring intervals.

#### How should this be manually tested?
After cloning the Repo, cd into it and activate the virtual environment. Install requirements into the virtual environment and run the command ./manage.py test hc/front/tests/test_update_timeout.py.

#### What are the relevant pivotal tracker stories?
#153727984